### PR TITLE
List row details

### DIFF
--- a/src/app/components/grid/index.html
+++ b/src/app/components/grid/index.html
@@ -51,7 +51,7 @@
     <sky-demo-page-property
       propertyName="detailsTemplate"
       [isOptional]="true">
-      Specifies a template for the row details. The template adds a dropdown at the end of each table that users can click to display details about the row. The template has access to the <code>row</code> variable that contains data for the entire row.
+      Specifies a template for the row details. The template adds a dropdown at the end of each row that users can click to display details about the row. The template has access to the <code>row</code> variable that contains data for the entire row.
     </sky-demo-page-property>
   </sky-demo-page-properties>
 

--- a/src/app/components/list/index.html
+++ b/src/app/components/list/index.html
@@ -73,6 +73,11 @@
       Specifies a set of filters to apply to list data. These filters will also create a filter summary if the <a routerLink="../list-filters">sky-list-filter-summary</a> component is included.
       Acceptable values: <code>Array of ListFilterModel</code>.
     </sky-demo-page-property>
+    <sky-demo-page-property
+      propertyName="detailsTemplate"
+      [isOptional]="true">
+      Specifies a template for the row details. The template adds a dropdown at the end of each row that users can click to display details about the row. The template has access to the <code>row</code> variable that contains data for the entire row.
+    </sky-demo-page-property>
   </sky-demo-page-properties>
 
   <sky-demo-page-properties sectionHeading="List events">

--- a/src/app/components/list/list-demo.component.html
+++ b/src/app/components/list/list-demo.component.html
@@ -3,7 +3,9 @@
 <sky-list [data]="items">
   <sky-list-toolbar></sky-list-toolbar>
 
-  <sky-list-view-grid fit="scroll">
+  <sky-list-view-grid
+    fit="scroll"
+    [detailsTemplate]="customDetailsTemplate">
     <sky-grid-column field="column1" heading="Column1"></sky-grid-column>
     <sky-grid-column field="column2" heading="Column2"></sky-grid-column>
     <sky-grid-column field="column3" heading="Column3"></sky-grid-column>
@@ -11,4 +13,23 @@
 
   <sky-list-paging pageSize="5"></sky-list-paging>
 </sky-list>
+
+<ng-template let-row="row" #customDetailsTemplate>
+  <table style="width:100%">
+    <tr>
+      <td>
+        <div>{{row.column2}} metrics</div>
+      </td>
+      <td>
+        <div>Total fruit eaten</div>
+        <div>{{row.consumptionCount}}</div>
+      </td>
+      <td>
+        <div>Initial fruit count</div>
+        <div>{{row.initialCount}}</div>
+      </td>
+    </tr>
+  </table>
+</ng-template>
+
 

--- a/src/app/components/list/list-demo.component.ts
+++ b/src/app/components/list/list-demo.component.ts
@@ -7,13 +7,13 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 })
 export class SkyListDemoComponent {
   public items: BehaviorSubject<any> = new BehaviorSubject([
-    { id: '1', column1: 101, column2: 'Apple', column3: 'Anne eats apples' },
-    { id: '2', column1: 202, column2: 'Banana', column3: 'Ben eats bananas' },
-    { id: '3', column1: 303, column2: 'Pear', column3: 'Patty eats pears' },
-    { id: '4', column1: 404, column2: 'Grape', column3: 'George eats grapes' },
-    { id: '5', column1: 505, column2: 'Banana', column3: 'Becky eats bananas' },
-    { id: '6', column1: 606, column2: 'Lemon', column3: 'Larry eats lemons' },
-    { id: '7', column1: 707, column2: 'Strawberry', column3: 'Sally eats strawberries' }
+    { id: '1', column1: 101, column2: 'Apple', column3: 'Anne eats apples', consumptionCount: 1, initialCount: 10},
+    { id: '2', column1: 202, column2: 'Banana', column3: 'Ben eats bananas', consumptionCount: 2, initialCount: 20},
+    { id: '3', column1: 303, column2: 'Pear', column3: 'Patty eats pears', consumptionCount: 3, initialCount: 30},
+    { id: '4', column1: 404, column2: 'Grape', column3: 'George eats grapes', consumptionCount: 4, initialCount: 40},
+    { id: '5', column1: 505, column2: 'Banana', column3: 'Becky eats bananas', consumptionCount: 5, initialCount: 50},
+    { id: '6', column1: 606, column2: 'Lemon', column3: 'Larry eats lemons', consumptionCount: 6, initialCount: 60},
+    { id: '7', column1: 707, column2: 'Strawberry', column3: 'Sally eats strawberries', consumptionCount: 7, initialCount: 70}
   ]);
 
   public changeData() {

--- a/src/app/components/list/list-demo.component.ts
+++ b/src/app/components/list/list-demo.component.ts
@@ -7,13 +7,20 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 })
 export class SkyListDemoComponent {
   public items: BehaviorSubject<any> = new BehaviorSubject([
-    { id: '1', column1: 101, column2: 'Apple', column3: 'Anne eats apples', consumptionCount: 1, initialCount: 10},
-    { id: '2', column1: 202, column2: 'Banana', column3: 'Ben eats bananas', consumptionCount: 2, initialCount: 20},
-    { id: '3', column1: 303, column2: 'Pear', column3: 'Patty eats pears', consumptionCount: 3, initialCount: 30},
-    { id: '4', column1: 404, column2: 'Grape', column3: 'George eats grapes', consumptionCount: 4, initialCount: 40},
-    { id: '5', column1: 505, column2: 'Banana', column3: 'Becky eats bananas', consumptionCount: 5, initialCount: 50},
-    { id: '6', column1: 606, column2: 'Lemon', column3: 'Larry eats lemons', consumptionCount: 6, initialCount: 60},
-    { id: '7', column1: 707, column2: 'Strawberry', column3: 'Sally eats strawberries', consumptionCount: 7, initialCount: 70}
+    { id: '1', column1: 101, column2: 'Apple', column3: 'Anne eats apples',
+      consumptionCount: 1, initialCount: 10},
+    { id: '2', column1: 202, column2: 'Banana', column3: 'Ben eats bananas',
+      consumptionCount: 2, initialCount: 20},
+    { id: '3', column1: 303, column2: 'Pear', column3: 'Patty eats pears',
+      consumptionCount: 3, initialCount: 30},
+    { id: '4', column1: 404, column2: 'Grape', column3: 'George eats grapes',
+      consumptionCount: 4, initialCount: 40},
+    { id: '5', column1: 505, column2: 'Banana', column3: 'Becky eats bananas',
+      consumptionCount: 5, initialCount: 50},
+    { id: '6', column1: 606, column2: 'Lemon', column3: 'Larry eats lemons',
+      consumptionCount: 6, initialCount: 60},
+    { id: '7', column1: 707, column2: 'Strawberry', column3: 'Sally eats strawberries',
+      consumptionCount: 7, initialCount: 70}
   ]);
 
   public changeData() {

--- a/src/modules/grid/grid.component.html
+++ b/src/modules/grid/grid.component.html
@@ -27,6 +27,7 @@
         <ng-container *ngFor="let item of items">
           <tr
             class="sky-grid-row"
+            [ngClass]="{'sky-grid-row-open': canRenderRowDetails() && item.detailsOpen}"
             [attr.sky-cmp-id]="item.id">
             <td
               class="sky-grid-cell"

--- a/src/modules/grid/grid.component.scss
+++ b/src/modules/grid/grid.component.scss
@@ -42,6 +42,10 @@
   float: left;
 }
 
+.sky-grid-row-open {
+  border-bottom: none;
+}
+
 .sky-grid-row-details {
   @include sky-border(row, bottom);
   padding: 8px;

--- a/src/modules/list-view-grid/list-view-grid.component.html
+++ b/src/modules/list-view-grid/list-view-grid.component.html
@@ -11,7 +11,8 @@
     (selectedColumnIdsChange)="columnIdsChanged($event)"
     [sortField]="sortField | async"
     (sortFieldChange)="sortFieldChanged($event)"
-    >
+    [detailsTemplate]="detailsTemplate"
+  >
   </sky-grid>
   <sky-wait [isWaiting]="loading | async"></sky-wait>
 </div>

--- a/src/modules/list-view-grid/list-view-grid.component.ts
+++ b/src/modules/list-view-grid/list-view-grid.component.ts
@@ -6,7 +6,8 @@ import {
   forwardRef,
   ChangeDetectionStrategy,
   ViewChild,
-  AfterContentInit
+  AfterContentInit,
+  TemplateRef
 } from '@angular/core';
 import { ListViewComponent } from '../list/list-view.component';
 import {
@@ -60,6 +61,9 @@ export class SkyListViewGridComponent
   public set name(value: string) {
     this.viewName = value;
   }
+
+  @Input()
+  public detailsTemplate: TemplateRef<any>;
 
   @Input()
   public displayedColumns: Array<string> | Observable<Array<string>>;

--- a/src/modules/list/fixtures/list.component.fixture.html
+++ b/src/modules/list/fixtures/list.component.fixture.html
@@ -4,7 +4,10 @@
   [sortFields]="sortFields"
 >
   <sky-list-toolbar #toolbar></sky-list-toolbar>
-  <sky-list-view-grid fit="scroll" #default>
+  <sky-list-view-grid
+    fit="scroll"
+    [detailsTemplate]="customDetailsTemplate"
+    #default>
     <sky-grid-column field="column1" heading="Column1">
       <ng-template let-row="row">{{row.column1}}</ng-template>
     </sky-grid-column>
@@ -18,3 +21,21 @@
     </sky-grid-column>
   </sky-list-view-grid>
 </sky-list>
+
+<ng-template let-row="row" #customDetailsTemplate>
+  <table style="width:100%">
+    <tr>
+      <td>
+        <div>{{row.column2}} metrics</div>
+      </td>
+      <td>
+        <div>Total fruit eaten</div>
+        <div>{{row.consumptionCount}}</div>
+      </td>
+      <td>
+        <div>Initial fruit count</div>
+        <div>{{row.initialCount}}</div>
+      </td>
+    </tr>
+  </table>
+</ng-template>

--- a/src/modules/list/list.component.spec.ts
+++ b/src/modules/list/list.component.spec.ts
@@ -42,6 +42,9 @@ import {
 } from './state';
 
 import { SkyListInMemoryDataProvider } from '../list-data-provider-in-memory';
+import {
+  expect
+} from '../testing';
 
 describe('List Component', () => {
   describe('List Fixture', () => {
@@ -62,20 +65,27 @@ describe('List Component', () => {
         /* tslint:disable */
         let itemsArray = [
           { id: '1', column1: '30', column2: 'Apple',
-            column3: 1, column4: moment().add(1, 'minute') },
+            column3: 1, column4: moment().add(1, 'minute'),
+            consumptionCount: 1, initialCount: 10},
           { id: '2', column1: '01', column2: 'Banana',
-            column3: 3, column4: moment().add(6, 'minute') },
+            column3: 3, column4: moment().add(6, 'minute'),
+            consumptionCount: 2, initialCount: 20},
           { id: '3', column1: '11', column2: 'Banana',
-            column3: 11, column4: moment().add(4, 'minute') },
+            column3: 11, column4: moment().add(4, 'minute'),
+            consumptionCount: 3, initialCount: 30},
           { id: '4', column1: '12', column2: 'Carrot',
-            column3: 12, column4: moment().add(2, 'minute') },
+            column3: 12, column4: moment().add(2, 'minute'),
+            consumptionCount: 4, initialCount: 40},
           { id: '5', column1: '12', column2: 'Edamame',
-            column3: 12, column4: moment().add(5, 'minute') },
+              column3: 12, column4: moment().add(5, 'minute'),
+            consumptionCount: 5, initialCount: 50},
           { id: '6', column1: null, column2: null,
-            column3: 20, column4: moment().add(3, 'minute') },
+              column3: 20, column4: moment().add(3, 'minute'),
+            consumptionCount: 6, initialCount: 60},
           { id: '7', column1: '22', column2: 'Grape',
-            column3: 21, column4: moment().add(7, 'minute') }
-        ];
+            column3: 21, column4: moment().add(7, 'minute'),
+            consumptionCount: 7, initialCount: 70}
+      ];
 
         bs = new BehaviorSubject<Array<any>>(itemsArray);
         items = bs.asObservable();
@@ -175,6 +185,31 @@ describe('List Component', () => {
             });
           });
         }));
+      });
+
+      describe('row details', () => {
+        it('opens and closes row details when the chevron icon is clicked', () => {
+          initializeList();
+          let details = nativeElement.querySelectorAll('sky-grid-details').item(0) as HTMLElement;
+          expect(details).not.toExist();
+          let detailsIcon = nativeElement.querySelectorAll('button.sky-chevron')
+            .item(0) as HTMLElement;
+          expect(detailsIcon).toHaveCssClass('sky-chevron-down');
+
+          detailsIcon.click();
+          fixture.detectChanges();
+          details = nativeElement.querySelectorAll('sky-grid-details').item(0) as HTMLElement;
+          expect(details).toExist();
+          detailsIcon = nativeElement.querySelectorAll('button.sky-chevron').item(0) as HTMLElement;
+          expect(detailsIcon).toHaveCssClass('sky-chevron-up');
+
+          detailsIcon.click();
+          fixture.detectChanges();
+          details = nativeElement.querySelectorAll('sky-grid-details').item(0) as HTMLElement;
+          expect(details).not.toExist();
+          detailsIcon = nativeElement.querySelectorAll('button.sky-chevron').item(0) as HTMLElement;
+          expect(detailsIcon).toHaveCssClass('sky-chevron-down');
+        });
       });
 
       describe('sorting', () => {
@@ -810,6 +845,13 @@ describe('List Component', () => {
         let response = provider.get(request);
         response.take(1).subscribe((r: any) => expect(r.count).toBe(2));
 
+      });
+
+      it('should not show chevron icons to expand row details when ' +
+        'detailsTemplate not configured', () => {
+        let detailsIcon = nativeElement.querySelectorAll('button.sky-chevron')
+          .item(0) as HTMLElement;
+        expect(detailsIcon).not.toExist();
       });
     });
 


### PR DESCRIPTION
@blackbaud/we-are-batman still getting feedback on this details drop down (https://github.com/blackbaud/skyux2/pull/972) but this pr would extend the details template functionality to sky-list (which is built on grid). im running into one css issue where one column has a darker line above it when the drop down is open. having trouble figuring out what's causing that
<img width="1184" alt="screen shot 2017-08-24 at 2 45 35 pm" src="https://user-images.githubusercontent.com/5074554/29685527-6c42b6f2-88db-11e7-80d7-790e12c5ed5b.png">